### PR TITLE
[WIP] Add fetchChildren and fetchRootPath

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ export const AccessType = {
  */
 export const ResourceIcons = {
   COLLECTION: 'collections',
+  FILE: 'insert_drive_file',
   FOLDER: 'folder',
   GROUP: 'people',
   ITEM: 'description',

--- a/src/containers/DataBrowserContainer.vue
+++ b/src/containers/DataBrowserContainer.vue
@@ -2,15 +2,15 @@
 div
   slot
     data-browser(ref="view", :model="model", :breadcrumbs="breadcrumbs", :items="items",
-        :folders="folders", :loading="fetching", :router-links="routerLinks",
+        :folders="folders", :files="files", :loading="fetching", :router-links="routerLinks",
         @uploadComplete="fetch", @folderCreated="fetch")
       slot(v-for="name in viewSlots", :name="name", :slot="name")
 </template>
 
 <script>
-import rest from '../rest';
-import { fetchingContainer, viewSlotWrapper } from '../utils/mixins';
-import DataBrowser from '../views/DataBrowser';
+import { fetchChildren, fetchRootPath } from '@/rest';
+import { fetchingContainer, viewSlotWrapper } from '@/utils/mixins';
+import DataBrowser from '@/views/DataBrowser';
 
 export default {
   components: { DataBrowser },
@@ -29,6 +29,7 @@ export default {
     breadcrumbs: [],
     items: [],
     folders: [],
+    files: [],
     fetching: false,
   }),
   computed: {
@@ -45,49 +46,24 @@ export default {
     fetch() {
       this.$refs.view.showUploader = false;
       this.fetching = true;
+
       this.items = [];
       this.folders = [];
+      this.files = [];
 
-      let fetchedFolders;
-      let fetchedItems = [];
-      const requests = [rest.get('/folder', {
-        params: {
-          parentId: this.model._id,
-          parentType: this.modelType,
-        },
-      }).then(({ data }) => {
-        fetchedFolders = data;
-      })];
-
-      if (this.modelType === 'folder') {
-        const fetchItems = rest.get('/item', {
-          params: {
-            folderId: this.model._id,
-          },
-        }).then(({ data }) => {
-          fetchedItems = data;
-        });
-
-        const fetchRootPath = rest.get(`/folder/${this.model._id}/rootpath`).then(({ data }) => {
-          this.breadcrumbs = data.concat([{
-            type: this.modelType,
-            object: this.model,
-          }]);
-        });
-
-        requests.push(fetchItems, fetchRootPath);
-      } else {
-        this.breadcrumbs = [{
-          type: this.modelType,
-          object: this.model,
-        }];
-      }
-
-      return Promise.all(requests).finally(() => {
-        this.folders = fetchedFolders;
-        this.items = fetchedItems;
-        this.fetching = false;
-      });
+      return (
+        fetchChildren(this.model)
+          .then((resources) => {
+            this.items = resources.filter(r => r._modelType === 'item');
+            this.folders = resources.filter(r => r._modelType === 'folder');
+            this.files = resources.filter(r => r._modelType === 'file');
+          })
+          .then(() => fetchRootPath(this.model))
+          .then((path) => {
+            this.breadcrumbs = path;
+            this.fetching = false;
+          })
+      );
     },
   },
 };

--- a/src/containers/ItemContainer.vue
+++ b/src/containers/ItemContainer.vue
@@ -1,0 +1,38 @@
+<template lang="pug">
+div
+  slot
+    item(v-if="item", :item="item", @destroy="destroy")
+</template>
+
+<script>
+import rest from '@/rest';
+import { fetchingContainer } from '@/utils/mixins';
+import Item from '@/views/Item';
+
+export default {
+  components: { Item },
+  mixins: [fetchingContainer],
+  props: {
+    id: {
+      default: null,
+      type: String,
+    },
+  },
+  data: () => ({
+    item: null,
+  }),
+  methods: {
+    destroy() {
+      return rest.delete(`/item/${this.id}`).then(() => {
+        this.$emit('destroyed', this.folder);
+        this.item = null;
+      });
+    },
+    fetch() {
+      return rest.get(`/item/${this.id}`).then(({ data }) => {
+        this.item = data;
+      });
+    },
+  },
+};
+</script>

--- a/src/rest.js
+++ b/src/rest.js
@@ -39,6 +39,56 @@ export const onResponse = (fn) => {
 };
 
 /**
+ * Fetch the child models of a resource.
+ * @param model The model to find the children of. It must minimally contain _id and _modelType.
+ * @returns A promise that resolves to the list of child models.
+ */
+export const fetchChildren = ({ _id, _modelType }) => {
+  const urlMap = {
+    collection: [`/folder?parentType=collection&parentId=${_id}`],
+    user: [`/folder?parentType=user&parentId=${_id}`],
+    folder: [`/folder?parentType=folder&parentId=${_id}`, `/item?folderId=${_id}`],
+    item: [`/item/${_id}/files`],
+  };
+  return (Promise.all((urlMap[_modelType] || []).map(url => instance.get(url)))
+    .then(result => result.reduce((agg, d) => [...agg, ...d.data], [])));
+};
+
+/**
+ * A root path object to represent the base element of a path (e.g. "collections" or "users").
+ * @param type The model type.
+ * @returns An object that may be used in a breadcrumb whose name is the plural of the model type.
+ */
+const rootObject = type => ({ type: `${type}s`, object: { name: `${type}s` } });
+
+/**
+ * Fetch the root path of a resource.
+ * @param model The model to retrieve the root path for.
+ * @returns A promise that resolves to the root path to the resource.
+ */
+export const fetchRootPath = (model) => {
+  const { _id, _modelType, itemId } = model;
+  const component = { type: _modelType, object: model };
+
+  // Special case for file. Would be nice if file had a rootpath endpoint.
+  if (_modelType === 'file') {
+    return (Promise.all([instance.get(`/item/${itemId}/rootpath`), instance.get(`/item/${itemId}`)])
+      .then(([path, item]) => [
+        rootObject(path.data[0].type),
+        ...path.data,
+        { type: 'item', object: item.data },
+        component,
+      ])
+    );
+  }
+
+  if (['user', 'collection'].indexOf(_modelType) >= 0) {
+    return Promise.resolve([rootObject(_modelType), component]);
+  }
+  return instance.get(`/${_modelType}/${_id}/rootpath`).then(r => [rootObject(r.data[0].type), ...r.data, component]);
+};
+
+/**
  * Convert an Object into an x-www-form-urlencoded string.
  * @param obj {Object} The object to encode
  */

--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import Layout from '@/views/Layout';
 import CollectionRoute from '@/routes/CollectionRoute';
 import CollectionsRoute from '@/routes/CollectionsRoute';
 import FolderRoute from '@/routes/FolderRoute';
+import ItemRoute from '@/routes/ItemRoute';
 import UserRoute from '@/routes/UserRoute';
 import UsersRoute from '@/routes/UsersRoute';
 
@@ -33,6 +34,9 @@ const layoutRoutes = [{
 }, {
   component: UserRoute,
   path: 'user/:id',
+}, {
+  component: ItemRoute,
+  path: 'item/:id',
 }, {
   // Legacy route, might remove in the future
   path: 'collection/:cid/folder/:id',

--- a/src/routes/ItemRoute.vue
+++ b/src/routes/ItemRoute.vue
@@ -1,0 +1,18 @@
+<template lang="pug">
+item-container(ref="wrapped", :id="$route.params.id", @destroyed="goToParent")
+</template>
+
+<script>
+import { fetchingRoute } from '@/utils/mixins';
+import ItemContainer from '@/containers/ItemContainer';
+
+export default {
+  components: { ItemContainer },
+  mixins: [fetchingRoute],
+  methods: {
+    goToParent(item) {
+      this.$router.push(`/folder/${item.folderId}`);
+    },
+  },
+};
+</script>

--- a/src/views/Item.vue
+++ b/src/views/Item.vue
@@ -1,0 +1,21 @@
+<template lang="pug">
+div
+  .display-1 {{ item.name }}
+  markdown.body-2(v-if="item.description", :text="item.description")
+  data-browser-container.mt-4(:model="item")
+</template>
+
+<script>
+import DataBrowserContainer from '../containers/DataBrowserContainer';
+import Markdown from './Markdown';
+
+export default {
+  components: { DataBrowserContainer, Markdown },
+  props: {
+    item: {
+      required: true,
+      type: Object,
+    },
+  },
+};
+</script>


### PR DESCRIPTION
@zachmullen PTAL.

Abstracts model differences into these functions and adds an item page that lists files.

Created in reference to https://github.com/girder/girder/issues/2628.

This may or may not be the right approach for this, but keeps more API logic in one place in `rest.js`. Not sure what checkboxes for files would do (my changes still seem buggy for files), but this could be useful.